### PR TITLE
chore: sort novels by id (desc)

### DIFF
--- a/app/api/novels/novel.ts
+++ b/app/api/novels/novel.ts
@@ -57,7 +57,8 @@ export async function getNovels(page = 1, limit = 10) {
 	const { data: novels, count } = await supabase
 		.from("novel")
 		.select("*, episode(count)", { count: 'exact' })
-		.range(from, from + limit - 1);
+		.range(from, from + limit - 1)
+		.order('novel_id', { ascending: false });
 
 	return { novels: novels as Novel[], count: count || 0 };
 }


### PR DESCRIPTION
## Improvements
[chore: sort novels by id (desc)](https://github.com/stratocanvas/dolce-biblioteca/commit/ea79257e3dbd26f94f03da43301ff1568c4a5d8f)
- `novel_id` 역순 정렬하여 최신 소설이 먼저 표시되도록 수정.